### PR TITLE
Replaced the deprecated set-output calls with the new GITHUB_OUTPUT mechanism.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16 # v1-node16 gets rid of the node12 deprecation warning
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     name: list cfn stack change set
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -7,9 +7,9 @@ jobs:
     name: list cfn stack change set
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16 # v1-node16 gets rid of the node12 deprecation warning
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,9 +30,9 @@ if [ ${status} != "CREATE_COMPLETE" ] && [ ${status} != "FAILED" ]; then
 fi
 
 result=$(cat $uuid.json | jq -c .)
-echo "::set-output name=change_set_name::$uuid"
-echo "::set-output name=result::$result"
-echo "::set-output name=result_file_path::$uuid.json"
+echo "change_set_name=$uuid" >> $GITHUB_OUTPUT
+echo "result=$result" >> $GITHUB_OUTPUT
+echo "result_file_path=$uuid.json" >> $GITHUB_OUTPUT
 
 python /pretty_format.py $uuid $INPUT_STACK_NAME
-echo "::set-output name=diff_file_path::$uuid.html"
+echo "diff_file_path=$uuid.html" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes #6.

This also required using newer versions of actions/checkout and aws-actions/configure-aws-credentials in the main.yml workflow